### PR TITLE
Add referrer as a download parameter

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -52,6 +52,12 @@ function downloadAgent() {
                         out: filename
                     };
                 }
+                if (downloadItem.referrer) {
+                    params = {
+                        ...params,
+                        referer: downloadItem.referrer,
+                    }
+                }
                 await aria2.call("addUri", [downloadUrl], params).then(async () => {
                     // Added successfully: Cancels and removes the download from browser download manager
                     function onFinished() { }


### PR DESCRIPTION
Right now some sites will return 403 code when you try to download a file using this extension as the referrer header is missing. To fix that I added referer parameter to aria call.