### PR TITLE
update notification icon path

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -77,7 +77,7 @@ function downloadAgent() {
           if (result.enablenotifications) {
             const notificationOptions = {
               type: 'basic',
-              iconUrl: 'assets/images/icon-large.png',
+              iconUrl: 'images/icon-large.png',
               title: 'Motrix WebExtension',
               message: 'Download started in Motrix download manger'
             };


### PR DESCRIPTION
Notifications seem to have stopped working. Changing path from /assets to root fixed the problem.