### PR TITLE
Add download with motrix context option

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -54,5 +54,21 @@
   "darkMode": {
     "message": "Dark mode",
     "description": "Dark mode"
+  },
+  "showOnlyAria": {
+    "message": "Show only Motrix downloads in the popup",
+    "description": "Show only Motrix downloads in the popup"
+  },
+  "hideChromeBar": {
+    "message": "Hide chrome download bar",
+    "description": "Hide chrome download bar"
+  },
+  "showContextOption": {
+    "message": "Show \"Download with Motrix\" context option",
+    "description": "Show \"Download with Motrix\" context option"
+  },
+  "downloadWithMotrix": {
+    "message": "Download with Motrix",
+    "description": "Download with Motrix"
   }
 }

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -13,12 +13,10 @@
     "128": "images/128.png"
   },
   "background": {
-    "scripts": [
-      "scripts/background.js"
-    ],
+    "scripts": ["scripts/background.js"],
     "persistent": true
   },
-  "content_security_policy":"script-src 'self' https://unpkg.com; object-src 'self'",
+  "content_security_policy": "script-src 'self' https://unpkg.com; object-src 'self'",
   "browser_action": {
     "browser_style": true,
     "default_icon": {
@@ -34,6 +32,7 @@
     "downloads",
     "downloads.shelf",
     "notifications",
-    "storage"
+    "storage",
+    "contextMenus"
   ]
 }

--- a/app/scripts/AriaDownloader.js
+++ b/app/scripts/AriaDownloader.js
@@ -74,6 +74,7 @@ async function onGot(result, downloadItem, history) {
         const status = await aria2.call('tellStatus', gid);
         history.set(gid, {
           gid: gid,
+          downloader: 'aria',
           startTime: downloadItem.startTime,
           icon: downloadItem.icon,
           name: params.out ?? null,
@@ -93,6 +94,7 @@ async function onGot(result, downloadItem, history) {
         });
         history.set(guid.gid, {
           gid: guid.gid,
+          downloader: 'aria',
           startTime: downloadItem.startTime,
           icon: downloadItem.icon,
           name: params.out ?? null,
@@ -108,6 +110,7 @@ async function onGot(result, downloadItem, history) {
       aria2.on('onDownloadComplete', ([guid]) => {
         history.set(guid.gid, {
           gid: guid.gid,
+          downloader: 'aria',
           startTime: downloadItem.startTime,
           icon: downloadItem.icon,
           name: params.out ?? null,

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -20,6 +20,9 @@ function ConfigView() {
   const [minFileSize, setMinFileSize] = useState('');
   const [blacklist, setBlacklist] = useState([]);
   const [darkMode, setDarkMode] = useState(false);
+  const [showOnlyAriaDownloads, setShowOnlyAriaDownloads] = useState(false);
+  const [hideChromeBar, setHideChromeBar] = useState(true);
+  const [showContextOption, setShowContextOption] = useState(true);
 
   useEffect(() => {
     browser.storage.sync
@@ -31,6 +34,9 @@ function ConfigView() {
         'minFileSize',
         'blacklist',
         'darkMode',
+        'showOnlyAria',
+        'hideChromeBar',
+        'showContextOption',
       ])
       .then(
         (result) => {
@@ -83,6 +89,27 @@ function ConfigView() {
             setDarkMode(false);
           } else {
             setDarkMode(result.darkMode);
+          }
+
+          if (typeof result.showOnlyAria === 'undefined') {
+            browser.storage.sync.set({ showOnlyAria: false });
+            setShowOnlyAriaDownloads(false);
+          } else {
+            setShowOnlyAriaDownloads(result.showOnlyAria);
+          }
+
+          if (typeof result.hideChromeBar === 'undefined') {
+            browser.storage.sync.set({ hideChromeBar: true });
+            setHideChromeBar(true);
+          } else {
+            setHideChromeBar(result.hideChromeBar);
+          }
+
+          if (typeof result.showContextOption === 'undefined') {
+            browser.storage.sync.set({ showContextOption: true });
+            setShowContextOption(true);
+          } else {
+            setShowContextOption(result.showContextOption);
           }
         },
         (error) => {
@@ -204,6 +231,69 @@ function ConfigView() {
                 });
                 setDarkMode((x) => !x);
                 window.location.reload(false);
+              }}
+            />
+          </Box>
+        </Grid>
+
+        {/* Show only aria switch */}
+        <Grid item xs={6}>
+          <FormLabel>__MSG_showOnlyAria__</FormLabel>
+        </Grid>
+        <Grid item xs={2}>
+          <Box display="flex" justifyContent="center">
+            <Switch
+              checked={showOnlyAriaDownloads}
+              onClick={() => {
+                browser.storage.sync.set({
+                  showOnlyAria: !showOnlyAriaDownloads,
+                });
+                setShowOnlyAriaDownloads((x) => !x);
+              }}
+            />
+          </Box>
+        </Grid>
+
+        {/* Show hide chrome bar switch */}
+        <Grid item xs={6}>
+          <FormLabel>__MSG_hideChromeBar__</FormLabel>
+        </Grid>
+        <Grid item xs={2}>
+          <Box display="flex" justifyContent="center">
+            <Switch
+              checked={hideChromeBar}
+              onClick={() => {
+                if (browser.downloads.setShelfEnabled) {
+                  browser.downloads.setShelfEnabled(!!hideChromeBar);
+                }
+                browser.storage.sync.set({
+                  hideChromeBar: !hideChromeBar,
+                });
+                setHideChromeBar((x) => !x);
+              }}
+            />
+          </Box>
+        </Grid>
+
+        {/* Show context option switch */}
+        <Grid item xs={6}>
+          <FormLabel>__MSG_showContextOption__</FormLabel>
+        </Grid>
+        <Grid item xs={2}>
+          <Box display="flex" justifyContent="center">
+            <Switch
+              checked={showContextOption}
+              onClick={() => {
+                browser.contextMenus.update(
+                  'motrix-webextension-download-context-menu-option',
+                  {
+                    visible: !showContextOption,
+                  }
+                );
+                browser.storage.sync.set({
+                  showContextOption: !showContextOption,
+                });
+                setShowContextOption((x) => !x);
               }}
             />
           </Box>

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -65,6 +65,7 @@ FolderButton.propTypes = {
 function PopupView() {
   const [downloadHistory, setDownloadHistory] = useState([]);
   const [extensionStatus, setExtensionStatus] = useState(false);
+  const [showOnlyAriaDownloads, setShowOnlyAriaDownloads] = useState(true);
 
   useEffect(() => {
     const updateHistory = () => {
@@ -82,8 +83,11 @@ function PopupView() {
   useEffect(() => {
     const updateStatus = () => {
       browser.storage.sync
-        .get(['extensionStatus'])
-        .then((r) => setExtensionStatus(r.extensionStatus));
+        .get(['extensionStatus', 'showOnlyAria'])
+        .then((r) => {
+          setExtensionStatus(r.extensionStatus);
+          setShowOnlyAriaDownloads(r.showOnlyAria ?? false);
+        });
     };
     const inter = setInterval(updateStatus, 1000);
     updateStatus();
@@ -152,48 +156,54 @@ function PopupView() {
         </IconButton>
       </Grid>
       <Grid item xs={11}>
-        {downloadHistory.slice(0, 4).map((el) => (
-          <Paper key={el.gid} style={{ display: 'flex', marginBottom: '8px' }}>
-            <div
-              style={{
-                padding: '8px',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-              }}
+        {downloadHistory
+          .filter((el) => !showOnlyAriaDownloads || el.downloader === 'aria')
+          .slice(0, 4)
+          .map((el) => (
+            <Paper
+              key={el.gid}
+              style={{ display: 'flex', marginBottom: '8px' }}
             >
-              <img src={el.icon ?? ''} />
-            </div>
-            <div
-              style={{
-                padding: '8px',
-                width: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-              }}
-            >
-              <div className="text">{parseName(el.name)}</div>
+              <div
+                style={{
+                  padding: '8px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                }}
+              >
+                <img src={el.icon ?? ''} />
+              </div>
+              <div
+                style={{
+                  padding: '8px',
+                  width: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                }}
+              >
+                <div className="text">{parseName(el.name)}</div>
 
-              <OptProgress
-                status={el.status}
-                downloaded={el.downloaded}
-                size={el.size}
-              />
-            </div>
-            <div
-              style={{
-                padding: '4px',
-                minWidth: '50px',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'center',
-              }}
-            >
-              <FolderButton element={el} />
-            </div>
-          </Paper>
-        ))}
+                <OptProgress
+                  status={el.status}
+                  downloaded={el.downloaded}
+                  size={el.size}
+                />
+              </div>
+              <div
+                style={{
+                  padding: '4px',
+                  minWidth: '50px',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                }}
+              >
+                <FolderButton element={el} />
+              </div>
+            </Paper>
+          ))}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Add a option for force downloading with motrix webextension.
![image](https://user-images.githubusercontent.com/34548796/193414479-124ae085-2256-4600-9313-d2a0c84dcd97.png)

This option will be useful for config where one would only occasionally want to download with motrix (they would set extension status to off etc and just start motrix download by right clicking on the link)