### PR TITLE
feat: Add cookies support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ You must download and install the Motrix download manager first to use this exte
 
 ![motrix-extension](https://user-images.githubusercontent.com/8397274/71557256-bed84a80-2a69-11ea-98d9-f2f20d2a0065.gif)
 
+![motrix-webextension-googledrive-demo](https://user-images.githubusercontent.com/76680670/232788367-f8386aa9-eaa6-45f7-8caa-a44dfdd3ec71.gif)
+
+
 ## How to use
 ### Demo video:
 - [Chrome](https://youtu.be/L0cEu-2LpOE)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ You must download and install the Motrix download manager first to use this exte
 
 ![motrix-extension](https://user-images.githubusercontent.com/8397274/71557256-bed84a80-2a69-11ea-98d9-f2f20d2a0065.gif)
 
-![motrix-webextension-googledrive-demo](https://user-images.githubusercontent.com/76680670/232788367-f8386aa9-eaa6-45f7-8caa-a44dfdd3ec71.gif)
-
-
 ## How to use
 ### Demo video:
 - [Chrome](https://youtu.be/L0cEu-2LpOE)

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -38,6 +38,10 @@
     "downloads.shelf",
     "notifications",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "cookies"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ]
 }

--- a/app/scripts/AriaDownloader.js
+++ b/app/scripts/AriaDownloader.js
@@ -119,7 +119,7 @@ async function onGot(result, downloadItem, history) {
       aria2.on('onDownloadStop', async ([guid]) => {
         const status = null;
         try {
-          status = await aria2.call('tellStatus', gid);
+          status = await aria2.call('tellStatus', guid.gid);
         } catch {
           
         }
@@ -141,7 +141,7 @@ async function onGot(result, downloadItem, history) {
       aria2.on('onDownloadError', async ([guid]) => {
         const status = null;
         try {
-          status = await aria2.call('tellStatus', gid);
+          status = await aria2.call('tellStatus', guid.gid);
         } catch {
           
         }

--- a/app/scripts/AriaDownloader.js
+++ b/app/scripts/AriaDownloader.js
@@ -54,6 +54,12 @@ async function onGot(result, downloadItem, history) {
       referer: downloadItem.referrer,
     };
   }
+  if (downloadItem.cookies) {
+    params = {
+      ...params,
+      header: `Cookie: ${downloadItem.cookies}`,
+    };
+  }
   if (result.enableDownloadPrompt) {
     const newPath = prompt(`Do you want to download:`, downloadItem.filename);
     if (newPath == null) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -26,7 +26,11 @@ async function downloadAgent() {
     subscribers.forEach((s) => s.next(delta));
   });
 
-  browser.downloads.onCreated.addListener(function (downloadItem) {
+  browser.downloads.onCreated.addListener(async function (downloadItem) {
+    const cookies = await browser.cookies.getAll({url: downloadItem.url});
+    const cookiesString = cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
+    downloadItem.cookies = cookiesString;
+    
     if (downloadItem.state !== 'in_progress') {
       return;
     }


### PR DESCRIPTION
## Feature
Add cookies support for downloading files that requires cookies (e.g. Google Drive)

Related to: #20, #113

## Description
I've tested this with Google Drive(& Google Docs), OneDrive, Dropbox and iCloud files, it successfully sent and downloaded the files on the abovementioned services with Motrix.

## NOTICE
* I tested it with Edge, but the package built with `yarn run build edge` does NOT work, while the package built with `yarn run build chrome` works.
* It requires `cookies` permission and `host_permissions: ["<all_urls>"]` to work