### PR TITLE
fix: service worker is not always alive

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -38,6 +38,7 @@
     "downloads.shelf",
     "notifications",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "offscreen"
   ]
 }

--- a/app/pages/offscreen.html
+++ b/app/pages/offscreen.html
@@ -1,0 +1,1 @@
+<script src="offscreen.js"></script>

--- a/app/pages/offscreen.html
+++ b/app/pages/offscreen.html
@@ -1,1 +1,1 @@
-<script src="offscreen.js"></script>
+<script src="../scripts/offscreen.js"></script>

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -151,9 +151,25 @@ export function createMenuItem() {
 browser.runtime.onStartup.addListener(function () {
   downloadAgent();
   createMenuItem();
+  createOffscreen();
 });
 
 browser.runtime.onInstalled.addListener(function () {
   downloadAgent();
   createMenuItem();
+  createOffscreen();
+});
+
+// create the offscreen document if it doesn't already exist
+async function createOffscreen() {
+  if (await chrome.offscreen.hasDocument?.()) return;
+  await chrome.offscreen.createDocument({
+    url: 'offscreen.html',
+    reasons: ['BLOBS'],
+    justification: 'keep service worker running',
+  });
+}
+// a message from an offscreen document every 20 second resets the inactivity timer
+chrome.runtime.onMessage.addListener(msg => {
+  if (msg.keepAlive) console.log('keepAlive');
 });

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -164,7 +164,7 @@ browser.runtime.onInstalled.addListener(function () {
 async function createOffscreen() {
   if (await chrome.offscreen.hasDocument?.()) return;
   await chrome.offscreen.createDocument({
-    url: 'offscreen.html',
+    url: 'pages/offscreen.html',
     reasons: ['BLOBS'],
     justification: 'keep service worker running',
   });

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -1,0 +1,4 @@
+// send a message every 20 sec to service worker
+setInterval(() => {
+    chrome.runtime.sendMessage({ keepAlive: true });
+  }, 20000);

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -1,4 +1,4 @@
 // send a message every 20 sec to service worker
 setInterval(() => {
-    chrome.runtime.sendMessage({ keepAlive: true });
-  }, 20000);
+  chrome.runtime.sendMessage({ keepAlive: true });
+}, 20000);


### PR DESCRIPTION
## Issue
As @gautamkrishnar mentioned in https://github.com/gautamkrishnar/motrix-webextension/issues/118#issuecomment-1512069338
>For manifest v3 extensions, the service worker won't always stay alive so the extension need to be converted to more of an event-driven approach

## Description
This PR aims to resolve this issue with the [Offscreen API](https://developer.chrome.com/blog/Offscreen-Documents-in-Manifest-v3/).
The solution referenced from [Persistent Service Worker in Chrome Extension](https://stackoverflow.com/a/66618269/16113175).

## Result
The service worker is still alive after the extension was turned on for hours, and can still send tasks to Motrix succesfully.
