### PR TITLE
fix: Use browser downloader when Motrix is not present

### DIFF
--- a/app/scripts/AriaDownloader.js
+++ b/app/scripts/AriaDownloader.js
@@ -176,6 +176,7 @@ async function onGot(result, downloadItem, history) {
         }
       });
     });
+  await removeFromHistory(downloadItem.id);
 }
 
 export default class AriaDownloader {
@@ -186,7 +187,7 @@ export default class AriaDownloader {
   async handleStart(options, downloadItem, history) {
     const result = options;
     // remove file from browsers history
-    await removeFromHistory(downloadItem.id);
+    await browser.downloads.pause(downloadItem.id);
     await onGot(result, downloadItem, history);
   }
 }

--- a/app/scripts/BrowserDownloader.js
+++ b/app/scripts/BrowserDownloader.js
@@ -41,7 +41,20 @@ export default class BrowserDownloader {
           size: downloadItem.totalBytes,
           downloaded: status.bytesReceived,
         });
-
+        browser.storage.local.set({ history: historyToArray(history) });
+      } else if (status.state !== 'in_progress') {
+        clearInterval(inter);
+        history.set(downloadItem.id, {
+          manager: 'browser',
+          gid: downloadItem.id,
+          startTime: downloadItem.startTime,
+          icon: downloadItem.icon,
+          name: path.out ?? null,
+          path: path.dir ?? null,
+          status: 'stop',
+          size: downloadItem.totalBytes,
+          downloaded: status.bytesReceived,
+        });
         browser.storage.local.set({ history: historyToArray(history) });
       } else {
         history.set(downloadItem.id, {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -102,7 +102,7 @@ async function downloadAgent() {
     };
 
     getResult.then(async (result) => {
-      const downloader = await getDownloader(result);
+      let downloader = await getDownloader(result);
 
       // wait for filename to be set
       if (!downloadItem.filename) {
@@ -119,7 +119,15 @@ async function downloadAgent() {
       const icon = await browser.downloads.getFileIcon(downloadItem.id);
       downloadItem.icon = icon;
 
-      await downloader.handleStart(result, downloadItem, history);
+      try {
+        await downloader.handleStart(result, downloadItem, history);
+      } catch {
+        if (downloader instanceof AriaDownloader) {
+          await browser.downloads.resume(downloadItem.id);
+          downloader = new BrowserDownloader();
+          downloader.handleStart(result, downloadItem, history);
+        }
+      }
     }, onError);
   });
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -125,7 +125,7 @@ async function downloadAgent() {
         if (downloader instanceof AriaDownloader) {
           await browser.downloads.resume(downloadItem.id);
           downloader = new BrowserDownloader();
-          downloader.handleStart(result, downloadItem, history);
+          await downloader.handleStart(result, downloadItem, history);
         }
       }
     }, onError);


### PR DESCRIPTION
## Issue
If Motrix is not running, the extension still captures and stops the downloads.

## Description
In this patch, when Motrix is not present, the browser will take over the downloading.

