### PR TITLE
feat: add setting to support browser's "Prompt before download" option

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -74,5 +74,9 @@
   "downloadFallback": {
     "message": "If launching in Motrix fails, use the browser's default download manager",
     "description": "If launching in Motrix fails, use the browser's default download manager"
+  },
+  "promptBeforeDownload": {
+    "message": "Prompt before download (\"Save As\" dialog)",
+    "description": "Enable if browser's 'Prompt before download' setting is turned on"
   }
 }

--- a/app/_locales/zh/messages.json
+++ b/app/_locales/zh/messages.json
@@ -74,5 +74,9 @@
   "downloadFallback": {
     "message": "如果 Motrix 启动失败，则使用浏览器的默认下载管理器",
     "description": "如果 Motrix 启动失败，则使用浏览器的默认下载管理器"
+  },
+  "promptBeforeDownload": {
+    "message": "下载前提示（"另存为"对话框）",
+    "description": "如果浏览器启用了"下载前提示"设置，请开启此选项"
   }
 }

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -52,7 +52,9 @@ async function handleDownload(downloadItem) {
     }
 
     // Pause immediately — before any async work — to minimise bytes the browser downloads
-    await browser.downloads.pause(downloadItem.id).catch(() => {});
+    if (!settings.promptBeforeDownload) {
+      await browser.downloads.pause(downloadItem.id).catch(() => {});
+    }
 
     if (!settings.motrixAPIkey) {
       await notify(
@@ -78,6 +80,10 @@ async function handleDownload(downloadItem) {
         waitForFilename(downloadItem.id),
         browser.cookies.getAll({ url: downloadItem.url }),
       ]);
+
+      if (settings.promptBeforeDownload) {
+        await browser.downloads.pause(downloadItem.id).catch(() => {});
+      }
 
       const path = parsePath(filename);
       const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -25,6 +25,7 @@ const DEFAULTS = {
   hideChromeBar: true,
   showContextOption: true,
   motrixPort: 16800,
+  promptBeforeDownload: false,
 };
 
 function save(patch) {
@@ -45,6 +46,7 @@ function ConfigView() {
   const [hideChromeBar, setHideChromeBar] = useState(DEFAULTS.hideChromeBar);
   const [showContextOption, setShowContextOption] = useState(DEFAULTS.showContextOption);
   const [motrixPort, setMotrixPort] = useState(DEFAULTS.motrixPort);
+  const [promptBeforeDownload, setPromptBeforeDownload] = useState(DEFAULTS.promptBeforeDownload);
 
   useEffect(() => {
     browser.storage.sync
@@ -62,6 +64,7 @@ function ConfigView() {
         setHideChromeBar(r.hideChromeBar);
         setShowContextOption(r.showContextOption);
         setMotrixPort(r.motrixPort);
+        setPromptBeforeDownload(r.promptBeforeDownload);
 
         // Persist defaults only for keys that were actually missing from storage
         const missing = Object.fromEntries(
@@ -243,6 +246,23 @@ function ConfigView() {
                 }
                 save({ hideChromeBar: next });
                 setHideChromeBar(next);
+              }}
+            />
+          </Box>
+        </Grid>
+
+        {/* Prompt before download */}
+        <Grid item xs={6}>
+          <FormLabel>__MSG_promptBeforeDownload__</FormLabel>
+        </Grid>
+        <Grid item xs={2}>
+          <Box display="flex" justifyContent="center">
+            <Switch
+              checked={promptBeforeDownload}
+              onClick={() => {
+                const next = !promptBeforeDownload;
+                save({ promptBeforeDownload: next });
+                setPromptBeforeDownload(next);
               }}
             />
           </Box>

--- a/app/scripts/services/SettingsCache.js
+++ b/app/scripts/services/SettingsCache.js
@@ -12,6 +12,7 @@ const DEFAULTS = {
   showContextOption: true,
   showOnlyAria: false,
   darkMode: false,
+  promptBeforeDownload: false,
 };
 
 class SettingsCache {


### PR DESCRIPTION
## Summary

This fixes an issue where download interception fails if the browser's 'Prompt before download' setting is enabled. A new toggle has been added to the extension's settings page. When enabled, it delays pausing the download until after the user has confirmed the 'Save As' dialog, preventing a race condition that caused the browser to handle the download directly.

## Changes

- **app/scripts/background.js**: The download handling logic in `handleDownload` is updated. The initial `pause` call is now conditional on a new `promptBeforeDownload` setting. If the setting is true, the pause is delayed until after `waitForFilename` resolves, preventing a race condition with the browser's 'Save As' dialog.
- **app/scripts/services/SettingsCache.js**: A new setting, `promptBeforeDownload`, is added to the `DEFAULTS` object with a default value of `false`. This allows the new setting to be stored and retrieved.
- **app/scripts/config.js**: The settings page is updated to include a new `Switch` component for the `promptBeforeDownload` setting. This includes adding it to `DEFAULTS`, creating a state variable, and loading/saving its value.

## Related Issue

Closes #136

